### PR TITLE
refactor: port discussions.py off requests onto PyGithub GraphQL

### DIFF
--- a/discussions.py
+++ b/discussions.py
@@ -2,21 +2,21 @@
 This module provides functions for working with discussions in a GitHub repository.
 
 Functions:
-    get_discussions(repo_url: str, token: str, search_query: str) -> List[Dict]:
+    get_discussions(github_connection: github.Github, search_query: str) -> List[Dict]:
         Get a list of discussions in a GitHub repository that match the search query.
 
 """
 
-import requests
+from github import Github
 
 
-def get_discussions(token: str, search_query: str, ghe: str):
+def get_discussions(github_connection: Github, search_query: str):
     """Get a list of discussions in a GitHub repository that match the search query.
 
     Args:
-        token (str): A personal access token for GitHub.
+        github_connection (github.Github): An authenticated PyGithub connection.
+            GitHub Enterprise routing is handled by the connection's base URL.
         search_query (str): The search query to filter discussions by.
-        ghe (str): GitHub Enterprise URL if applicable, or None for github.com.
 
     Returns:
         list: A list of discussions in the repository that match the search query.
@@ -64,10 +64,9 @@ def get_discussions(token: str, search_query: str, ghe: str):
     # Remove the type:discussions filter from the search query
     search_query = search_query.replace("type:discussions ", "")
 
-    # Send the GraphQL request
-    api_endpoint = f"{ghe}/api" if ghe else "https://api.github.com"
-    headers = {"Authorization": f"Bearer {token}"}
-
+    # PyGithub's graphql_query reuses the connection's auth, base URL, and
+    # GitHub Enterprise /api/graphql handling, and raises GithubException on
+    # HTTP or GraphQL errors.
     discussions = []
     cursor = None
 
@@ -76,22 +75,7 @@ def get_discussions(token: str, search_query: str, ghe: str):
         variables = {"query": search_query, "cursor": cursor}
 
         # Send the GraphQL request
-        response = requests.post(
-            f"{api_endpoint}/graphql",
-            json={"query": query, "variables": variables},
-            headers=headers,
-            timeout=60,
-        )
-
-        # Check for errors in the GraphQL response
-        if response.status_code != 200:
-            raise ValueError(
-                f"GraphQL query failed with status code {response.status_code}"
-            )
-
-        response_json = response.json()
-        if "errors" in response_json:
-            raise ValueError(f"GraphQL query failed: {response_json['errors']}")
+        _, response_json = github_connection.requester.graphql_query(query, variables)
 
         data = response_json["data"]
 

--- a/discussions.py
+++ b/discussions.py
@@ -2,7 +2,7 @@
 This module provides functions for working with discussions in a GitHub repository.
 
 Functions:
-    get_discussions(github_connection: github.Github, search_query: str) -> List[Dict]:
+    get_discussions(github_connection: Github, search_query: str) -> list:
         Get a list of discussions in a GitHub repository that match the search query.
 
 """
@@ -14,7 +14,7 @@ def get_discussions(github_connection: Github, search_query: str):
     """Get a list of discussions in a GitHub repository that match the search query.
 
     Args:
-        github_connection (github.Github): An authenticated PyGithub connection.
+        github_connection (Github): An authenticated PyGithub connection.
             GitHub Enterprise routing is handled by the connection's base URL.
         search_query (str): The search query to filter discussions by.
 

--- a/issue_metrics.py
+++ b/issue_metrics.py
@@ -307,7 +307,7 @@ def main():  # pragma: no cover
             raise ValueError(
                 "The search query for discussions cannot include labels to measure"
             )
-        issues = get_discussions(token, search_query, ghe)
+        issues = get_discussions(github_connection, search_query)
         if len(issues) <= 0:
             print("No discussions found")
             write_to_markdown(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "numpy==2.4.6",
     "python-dotenv==1.2.2",
     "pytz==2026.2",
-    "requests==2.34.2",
 ]
 
 [dependency-groups]
@@ -22,5 +21,4 @@ dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
     "types-pytz==2026.2.0.20260518",
-    "types-requests==2.33.0.20260712",
 ]

--- a/test_discussions.py
+++ b/test_discussions.py
@@ -6,9 +6,10 @@ Classes:
 """
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from discussions import get_discussions
+from github import GithubException
 
 
 class TestGetDiscussions(unittest.TestCase):
@@ -17,7 +18,7 @@ class TestGetDiscussions(unittest.TestCase):
     def _create_mock_response(
         self, discussions, has_next_page=False, end_cursor="cursor123"
     ):
-        """Helper method to create a mock GraphQL response."""
+        """Helper method to create a mock GraphQL response body."""
         return {
             "data": {
                 "search": {
@@ -27,8 +28,7 @@ class TestGetDiscussions(unittest.TestCase):
             }
         }
 
-    @patch("requests.post")
-    def test_get_discussions_single_page(self, mock_post):
+    def test_get_discussions_single_page(self):
         """Test the get_discussions function with a single page of results."""
         # Mock data for two discussions
         mock_discussions = [
@@ -50,13 +50,15 @@ class TestGetDiscussions(unittest.TestCase):
             },
         ]
 
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = self._create_mock_response(
-            mock_discussions, has_next_page=False
+        github_connection = MagicMock()
+        # graphql_query returns (headers, response_json)
+        github_connection.requester.graphql_query.return_value = (
+            {},
+            self._create_mock_response(mock_discussions, has_next_page=False),
         )
 
         discussions = get_discussions(
-            "token", "repo:user/repo type:discussions query", ""
+            github_connection, "repo:user/repo type:discussions query"
         )
 
         # Check that the function returns the expected discussions
@@ -65,10 +67,9 @@ class TestGetDiscussions(unittest.TestCase):
         self.assertEqual(discussions[1]["title"], "Discussion 2")
 
         # Verify only one API call was made
-        self.assertEqual(mock_post.call_count, 1)
+        self.assertEqual(github_connection.requester.graphql_query.call_count, 1)
 
-    @patch("requests.post")
-    def test_get_discussions_multiple_pages(self, mock_post):
+    def test_get_discussions_multiple_pages(self):
         """Test the get_discussions function with multiple pages of results."""
         # Mock data for pagination
         page1_discussions = [
@@ -93,17 +94,20 @@ class TestGetDiscussions(unittest.TestCase):
             }
         ]
 
-        # Configure mock to return different responses for each call
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.side_effect = [
-            self._create_mock_response(
-                page1_discussions, has_next_page=True, end_cursor="cursor123"
+        github_connection = MagicMock()
+        # Return a different page for each call
+        github_connection.requester.graphql_query.side_effect = [
+            (
+                {},
+                self._create_mock_response(
+                    page1_discussions, has_next_page=True, end_cursor="cursor123"
+                ),
             ),
-            self._create_mock_response(page2_discussions, has_next_page=False),
+            ({}, self._create_mock_response(page2_discussions, has_next_page=False)),
         ]
 
         discussions = get_discussions(
-            "token", "repo:user/repo type:discussions query", ""
+            github_connection, "repo:user/repo type:discussions query"
         )
 
         # Check that all discussions were returned
@@ -112,29 +116,20 @@ class TestGetDiscussions(unittest.TestCase):
         self.assertEqual(discussions[1]["title"], "Discussion 2")
 
         # Verify that two API calls were made
-        self.assertEqual(mock_post.call_count, 2)
+        self.assertEqual(github_connection.requester.graphql_query.call_count, 2)
 
-    @patch("requests.post")
-    def test_get_discussions_error_status_code(self, mock_post):
-        """Test the get_discussions function with a failed HTTP response."""
-        mock_post.return_value.status_code = 500
+        # Verify the second call paginated using the first page's end cursor
+        second_call_variables = (
+            github_connection.requester.graphql_query.call_args_list[1].args[1]
+        )
+        self.assertEqual(second_call_variables["cursor"], "cursor123")
 
-        with self.assertRaises(ValueError) as context:
-            get_discussions("token", "repo:user/repo type:discussions query", "")
-
-        self.assertIn(
-            "GraphQL query failed with status code 500", str(context.exception)
+    def test_get_discussions_propagates_github_exception(self):
+        """A GithubException raised by graphql_query propagates to the caller."""
+        github_connection = MagicMock()
+        github_connection.requester.graphql_query.side_effect = GithubException(
+            500, "boom", None
         )
 
-    @patch("requests.post")
-    def test_get_discussions_graphql_error(self, mock_post):
-        """Test the get_discussions function with GraphQL errors in response."""
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {
-            "errors": [{"message": "GraphQL Error"}]
-        }
-
-        with self.assertRaises(ValueError) as context:
-            get_discussions("token", "repo:user/repo type:discussions query", "")
-
-        self.assertIn("GraphQL query failed:", str(context.exception))
+        with self.assertRaises(GithubException):
+            get_discussions(github_connection, "repo:user/repo type:discussions query")

--- a/test_discussions.py
+++ b/test_discussions.py
@@ -128,7 +128,7 @@ class TestGetDiscussions(unittest.TestCase):
         """A GithubException raised by graphql_query propagates to the caller."""
         github_connection = MagicMock()
         github_connection.requester.graphql_query.side_effect = GithubException(
-            500, "boom", None
+            500, {"message": "server error"}, None
         )
 
         with self.assertRaises(GithubException):

--- a/uv.lock
+++ b/uv.lock
@@ -489,7 +489,6 @@ dependencies = [
     { name = "pygithub" },
     { name = "python-dotenv" },
     { name = "pytz" },
-    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -503,7 +502,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "types-pytz" },
-    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -512,7 +510,6 @@ requires-dist = [
     { name = "pygithub", specifier = "==2.9.1" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "pytz", specifier = "==2026.2" },
-    { name = "requests", specifier = "==2.34.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -526,7 +523,6 @@ dev = [
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "types-pytz", specifier = "==2026.2.0.20260518" },
-    { name = "types-requests", specifier = "==2.33.0.20260712" },
 ]
 
 [[package]]
@@ -1075,18 +1071,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/d9/9fa4019d2235bd374293e1fd4153879b28b6ae1d2bae98addd352c9713f2/types_pytz-2026.2.0.20260518.tar.gz", hash = "sha256:e5d254329e9c4e91f0781b22c43a4bb2d10bb044d97b24c4b05d45567b0eae16", size = 10871, upload-time = "2026-05-18T06:02:45.789Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/89/41e80670779a223d8bc8bc83019a619988cfa5c432cedac5cec23884fbc4/types_pytz-2026.2.0.20260518-py3-none-any.whl", hash = "sha256:3a12eaa38f476bd650902a9c9bb442f03f3c7dee2be5c5848bce61bd708d205a", size = 10125, upload-time = "2026-05-18T06:02:44.968Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260712"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084, upload-time = "2026-07-12T05:14:20.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392, upload-time = "2026-07-12T05:14:19.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #790
Relates to #799

## Proposed Changes

Port `get_discussions()` from a direct `requests.post` GraphQL call to PyGithub's `github_connection.requester.graphql_query`, so PyGithub owns all HTTP (auth, base URL, and GitHub Enterprise `/api/graphql` routing) and `requests` is no longer a direct dependency.

- `discussions.py`: signature is now `get_discussions(github_connection, search_query)`. The manual status-code and `errors` checks are gone because `graphql_query` raises `GithubException` on both HTTP and GraphQL errors, which now propagates.
- `issue_metrics.py`: the single caller passes the existing `github_connection`.
- `test_discussions.py`: mocks the PyGithub GraphQL call instead of `requests.post`, adds a pagination-cursor assertion, and replaces the two removed error-path tests with an exception-propagation test.
- `pyproject.toml` / `uv.lock`: drop `requests` and `types-requests` as direct dependencies. `requests` remains transitively via PyGithub.

**Proof it works:** `make test` passes (206 tests, 100% coverage, `discussions.py` at 100%). A spike confirmed `graphql_query` returns `(headers, {"data": {...}})` and derives the correct GHE endpoint from the connection base URL (`https://ghe.example.com/api/graphql`).

**Risk + AI role:** Low. Narrow surface with one internal caller. AI-assisted implementation, independently reviewed across four models.

**Behavioral notes (pre-existing inconsistencies, tracked in #799):**
- Discussions now route via the connection base URL, consistent with every other call in the tool. GitHub App users on GHE must set `GITHUB_APP_ENTERPRISE_ONLY=true` for discussions to reach GHE (they already needed it for all other calls to work).
- The request timeout is now PyGithub's default rather than the discussions-only 60s, matching the rest of the tool.

**Review focus:** The removal of the manual error checks (relying on `GithubException` to propagate), and the GHE routing note for GitHub App auth.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
